### PR TITLE
Upper case RELEASE_X_Y in docker version

### DIFF
--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -69,7 +69,7 @@ jobs:
           ## Find what Bioconductor RELEASE branch we are working on
           ## otherwise, assume we are working on bioc-devel.
           if echo "$GITHUB_REF" | grep -q "RELEASE_"; then
-              biocversion="$(basename -- $GITHUB_REF | tr '[:upper:]' '[:lower:]')"
+              biocversion="$(basename -- $GITHUB_REF)"
           else
               biocversion="devel"
           fi


### PR DESCRIPTION
Bioconductor uses uppser case RELEASE_X_Y for the [docker](https://hub.docker.com/r/bioconductor/bioconductor_docker#current) image tag. As #3 pointed out the issue and fixed [here](https://github.com/sa-lee/fluentGenomics/runs/698422052?check_suite_focus=true).