### PR TITLE
Fix references to "biocversion"

### DIFF
--- a/actions/check-bioc.yml
+++ b/actions/check-bioc.yml
@@ -160,8 +160,8 @@ jobs:
           fi
 
           ## Define the R and Bioconductor version numbers
-          biocversionnum=$(Rscript -e "info <- BiocManager:::.version_map_get_online('https://bioconductor.org/config.yaml'); res <- subset(info, BiocStatus == '${biocversion}')[, 'Bioc']; cat(as.character(res))")
-          rversion=$(Rscript -e "info <- BiocManager:::.version_map_get_online('https://bioconductor.org/config.yaml'); res <- subset(info, BiocStatus == '${biocversion}')[, 'R']; cat(as.character(res))")
+          biocversionnum=$(Rscript -e "info <- BiocManager:::.version_map_get_online('https://bioconductor.org/config.yaml'); res <- subset(info, BiocStatus == '${{ needs.define-docker-info.outputs.biocversion }}')[, 'Bioc']; cat(as.character(res))")
+          rversion=$(Rscript -e "info <- BiocManager:::.version_map_get_online('https://bioconductor.org/config.yaml'); res <- subset(info, BiocStatus == '${{ needs.define-docker-info.outputs.biocversion }}')[, 'R']; cat(as.character(res))")
 
           ## Print the results
           echo $biocversion


### PR DESCRIPTION
The `biocversion` variable is defined by the `define-docker-info` action. To access its value from other actions we need to specify in full its origin.