### PR TITLE
Split up install dependencies pass 1 and 2

### DIFF
--- a/inst/templates/check-bioc.yml
+++ b/inst/templates/check-bioc.yml
@@ -170,7 +170,7 @@ jobs:
           ## Pass #1 at installing dependencies
           message(paste('****', Sys.time(), 'pass number 1 at installing dependencies: local dependencies ****'))
           remotes::install_local(dependencies = TRUE, repos = BiocManager::repositories(), build_vignettes = TRUE, upgrade = TRUE)
-          quit(status=0)
+        continue-on-error: true
         shell: Rscript {0}
 
       - name: Install dependencies pass 2

--- a/inst/templates/check-bioc.yml
+++ b/inst/templates/check-bioc.yml
@@ -153,7 +153,7 @@ jobs:
           BiocManager::install(version = "${{ matrix.config.bioc }}", ask = FALSE)
         shell: Rscript {0}
 
-      - name: Install dependencies
+      - name: Install dependencies pass 1
         run: |
           ## Try installing the package dependencies in steps. First the local
           ## dependencies, then any remaining dependencies to avoid the
@@ -161,20 +161,24 @@ jobs:
           ## https://stat.ethz.ch/pipermail/bioc-devel/2020-April/016675.html
           ## https://github.com/r-lib/remotes/issues/296
           ## Ideally, all dependencies should get installed in the first pass.
-
+          
           ## Temporary for now due to https://github.com/ropensci/RefManageR/issues/79
           remotes::install_github("ropensci/bibtex")
           remotes::install_github("ropensci/RefManageR")
           remotes::install_github("cboettig/knitcitations")
-
+          
           ## Pass #1 at installing dependencies
           message(paste('****', Sys.time(), 'pass number 1 at installing dependencies: local dependencies ****'))
           remotes::install_local(dependencies = TRUE, repos = BiocManager::repositories(), build_vignettes = TRUE, upgrade = TRUE)
+          quit(status=0)
+        shell: Rscript {0}
 
+      - name: Install dependencies pass 2
+        run: |
           ## Pass #2 at installing dependencies
           message(paste('****', Sys.time(), 'pass number 2 at installing dependencies: any remaining dependencies ****'))
           remotes::install_local(dependencies = TRUE, repos = BiocManager::repositories(), build_vignettes = TRUE, upgrade = TRUE)
-
+          
           ## For running the checks
           message(paste('****', Sys.time(), 'installing rcmdcheck and BiocCheck ****'))
           remotes::install_cran("rcmdcheck")


### PR DESCRIPTION
If one of the packages fails being installed during pass 1, 
R exits with an status != 0, causing the entire workflow to halt. 

As errors may happen during this step, I suggest to split up pass 1 and 2, explicitly allowing
errors in pass 1 using `continue-on-error: true`. 