### PR TITLE
Suggest testthat when invoking `use_bioc_vignette`

### DIFF
--- a/R/use_bioc_vignette.R
+++ b/R/use_bioc_vignette.R
@@ -39,6 +39,7 @@ use_bioc_vignette <- function(name, title = name) {
     use_package("BiocStyle", "Suggests")
     use_package("RefManageR", "Suggests")
     use_package("sessioninfo", "Suggests")
+    use_package("testthat", "Suggests")
     usethis:::use_description_field("VignetteBuilder", "knitr", overwrite = TRUE)
     use_git_ignore("inst/doc")
     biocthis_vignette_template("vignette.Rmd", name, title)


### PR DESCRIPTION
The `vignette.Rmd` template makes use of the `testthat` package 

https://github.com/lcolladotor/biocthis/blob/c06e66d60bd864ef67dffb09f1efb2d5179c62de/inst/templates/vignette.Rmd#L47

but it is not added to the **Suggests**. This PR reconciles that discrepancy.