### PR TITLE
new url for guidelines on the description file

### DIFF
--- a/inst/templates/03_core_files.R
+++ b/inst/templates/03_core_files.R
@@ -7,7 +7,7 @@ rstudioapi::navigateToFile(usethis::proj_path("dev", "02_git_github_setup.R"))
 
 ## Edit your package DESCRIPTION file
 ## Check http://r-pkgs.had.co.nz/description.html for details
-## as well as http://bioconductor.org/developers/package-guidelines/#description
+## as well as http://contributions.bioconductor.org/description.html
 
 ## Check https://github.com/lcolladotor/biocthis/blob/master/DESCRIPTION
 ## for an example.


### PR DESCRIPTION
the old url is still valid, but the contents of that page have been re-written at the new url