### PR TITLE
separate bug report and feature requests

### DIFF
--- a/inst/templates/bioc-feature-request.md
+++ b/inst/templates/bioc-feature-request.md
@@ -1,0 +1,38 @@
+---
+name: Feature Request
+about: Suggest an idea for this package
+title: "[Feature Request] A short description of the feature"
+labels: ''
+assignees: ''
+---
+
+Please ask questions about how to use `{{{Package}}}` on the Bioconductor
+Support Site at <https://support.bioconductor.org> using the appropriate tag(s)
+including the one for this package.
+
+**Note**. Update the issue title to summarize the feature request.
+
+## Is the feature request related to a problem?
+
+Please provide a clear and concise description of what the problem
+is. Ex. I'm always frustrated when [...]
+
+## Describe the solution
+
+A clear and concise description of what you want to happen.
+
+## Describe any alternatives considered
+
+A clear and concise description of any alternative solutions or
+features you've considered.
+
+## Additional context
+
+Add any other context about the feature request here. You may include web links
+(e.g., from GitHub) to:
+
+* raw code
+* a commit
+* code inside a commit
+* code from an R package
+

--- a/inst/templates/bioc-issue.md
+++ b/inst/templates/bioc-issue.md
@@ -41,8 +41,8 @@ Indicate whether `BiocManager::valid()` returns `TRUE`.
 
 - [ ] `BiocManager::valid()` is `TRUE`
 
-Note. To avoid potential issues with version mixing and reproducibility, do not
-install packages from `GitHub`.
+**Note**. To avoid potential issues with version mixing and reproducibility, do
+not install packages from `GitHub`.
 
 ## Additional Context
 
@@ -53,5 +53,14 @@ Provide some additional context for the bug report. You may include web links
 * a commit
 * code inside a commit
 * code from an R package
+
+## Is the package installed via bioconda? 
+
+We find that [bioconda](https://bioconda.github.io/) installations can often be
+problematic due to the nature of the setup environment and potential for version
+mixing.
+
+The preferred method for installing Bioconductor software through `BiocManager`
+and we do not support issues related to `bioconda` installations at this time.
 
 

--- a/inst/templates/bioc-issue.md
+++ b/inst/templates/bioc-issue.md
@@ -6,9 +6,9 @@ labels: ''
 assignees: ''
 ---
 
-Please ask questions about how to use `{{{Package}}}` on the Bioconductor
-Support Site at <https://support.bioconductor.org> using the appropriate tag(s)
-including the one for this package.
+Please ask questions about how to use `{{{Package}}}` on the
+[Bioconductor Support Site](https://support.bioconductor.org) using the
+appropriate tag(s) including the one for this package.
 
 **Note**. Update the issue title to concisely describe the bug.
 
@@ -18,11 +18,12 @@ Please provide a clear and concise description of what the bug is.
 
 ### Provide a minimally reproducible example (reprex)
 
-Provide a clear and concise description of the bug. It can be best illustrated
-with a minimally reproducible example using
-[`reprex::reprex()`](https://reprex.tidyverse.org/reference/reprex.html).
-For tips, see this link on Stackoverflow:
-<https://stackoverflow.com/questions/5963269/how-to-make-a-great-r-reproducible-example>
+Provide a clear and concise description of the bug. It can be easily (but not
+necessarily) illustrated with a minimally reproducible example using the
+[`reprex` package](https://reprex.tidyverse.org/articles/learn-reprex.html).
+
+For tips on creating a reprex, see this
+[StackOverflow link](https://stackoverflow.com/questions/5963269/how-to-make-a-great-r-reproducible-example).
 
 ## Expected behavior
 

--- a/inst/templates/bioc-issue.md
+++ b/inst/templates/bioc-issue.md
@@ -37,8 +37,12 @@ options(width = 120)
 ## insert session info here
 ```
 
-Note. The output of `sessioninfo::session_info()` includes relevant GitHub
-installation information and other details that are missed by `sessionInfo()`.
+Indicate whether `BiocManager::valid()` returns `TRUE`. 
+
+- [ ] `BiocManager::valid()` is `TRUE`
+
+Note. To avoid potential issues with version mixing and reproducibility, do not
+install packages from `GitHub`.
 
 ## Additional Context
 

--- a/inst/templates/bioc-issue.md
+++ b/inst/templates/bioc-issue.md
@@ -1,56 +1,53 @@
 ---
-name: Bug report or feature request
-about: Describe a bug you've seen or make a case for a new feature
-title: "[BUG] Your bug or feature request"
+name: Bug Report
+about: Describe the bug in detail
+title: "[BUG] A short description of the bug"
 labels: ''
 assignees: ''
 ---
 
-Please briefly describe your problem and what output you expect. If you have a question, please don't use this form. Instead, ask on <https://support.bioconductor.org/> using the appropriate tag(s) including one for this package.
+Please ask questions about how to use `{{{Package}}}` on the Bioconductor
+Support Site at <https://support.bioconductor.org> using the appropriate tag(s)
+including the one for this package.
 
-## Context
+**Note**. Update the issue title to concisely describe the bug.
 
-Provide some context for your bug report or feature request. This could be the:
+## Describe the bug
 
-* link to raw code, example: https://github.com/lcolladotor/osca_LIIGH_UNAM_2020/blob/master/00-template.Rmd#L24-L28
-* link to a commit, example: https://github.com/lcolladotor/osca_LIIGH_UNAM_2020/commit/6aa30b22eda614d932c12997ba611ba582c435d7
-* link to a line of code inside a commit, example: https://github.com/lcolladotor/osca_LIIGH_UNAM_2020/commit/6aa30b22eda614d932c12997ba611ba582c435d7#diff-e265269fe4f17929940e81341b92b116R17
-* link to code from an R package, example: https://github.com/LieberInstitute/spatialLIBD/blob/master/R/run_app.R#L51-L55
+Please provide a clear and concise description of what the bug is.
 
-## Code
+### Provide a minimally reproducible example (reprex)
 
-Include the code you ran and comments
+Provide a clear and concise description of the bug that is best illustrated
+with a minimally reproducible example using
+[`reprex::reprex()`](https://reprex.tidyverse.org/reference/reprex.html).
+For tips, see this link on Stackoverflow:
+<https://stackoverflow.com/questions/5963269/how-to-make-a-great-r-reproducible-example>
 
-```R
-## prompt an error
-stop('hola')
+## Expected behavior
 
-## check the error trace
-traceback()
-```
+A clear and concise description of what you expected to happen.
 
-## Small reproducible example
+## R Session Information
 
-If you copy the lines of code that lead to your error, you can then run [`reprex::reprex()`](https://reprex.tidyverse.org/reference/reprex.html) which will create a small website with code you can then easily copy-paste here in a way that will be easy to work with later on.
-
-```R
-## prompt an error
-stop('hola')
-#> Error in eval(expr, envir, enclos): hola
-
-## check the error trace
-traceback()
-#> No traceback available
-```
-
-
-## R session information
-
-Remember to include your full R session information.
+Please report the output of either `sessionInfo()` or `session_info()` here.
 
 ```R
 options(width = 120)
-sessioninfo::session_info()
+## insert session info here
 ```
 
-The output of `sessioninfo::session_info()` includes relevant GitHub installation information and other details that are missed by `sessionInfo()`.
+Note. The output of `sessioninfo::session_info()` includes relevant GitHub
+installation information and other details that are missed by `sessionInfo()`.
+
+## Additional Context
+
+Provide some additional context for the bug report. You may include web links
+(e.g., from GitHub) to:
+
+* raw code
+* a commit
+* code inside a commit
+* code from an R package
+
+

--- a/inst/templates/bioc-issue.md
+++ b/inst/templates/bioc-issue.md
@@ -18,7 +18,7 @@ Please provide a clear and concise description of what the bug is.
 
 ### Provide a minimally reproducible example (reprex)
 
-Provide a clear and concise description of the bug that is best illustrated
+Provide a clear and concise description of the bug. It can be best illustrated
 with a minimally reproducible example using
 [`reprex::reprex()`](https://reprex.tidyverse.org/reference/reprex.html).
 For tips, see this link on Stackoverflow:

--- a/inst/templates/bioc-support.md
+++ b/inst/templates/bioc-support.md
@@ -5,7 +5,7 @@ Before filing an issue, there are a few places to explore and pieces to put toge
 
 ## Make a reprex
 
-Start by making a minimal **repr**oducible **ex**ample using the  [reprex](https://reprex.tidyverse.org/) package.
+Start by making a minimal **repr**oducible **ex**ample using the [reprex](https://reprex.tidyverse.org/) package.
 If you haven't heard of or used reprex before, you're in for a treat!
 Seriously, reprex will make all of your R-question-asking endeavors easier (which is a pretty insane ROI for the five to ten minutes it'll take you to learn what it's all about).
 For additional reprex pointers, check out the [Get help!](https://www.tidyverse.org/help/) section of the tidyverse site.
@@ -21,15 +21,24 @@ Armed with your reprex, the next step is to figure out [where to ask](https://ww
 *   If you're not sure: let the community help you figure it out!
     If your problem _is_ a bug or a feature request, you can easily return here and report it.
 
-Before opening a new issue, be sure to [search issues and pull requests](https://github.com/{{github_spec}}/issues) to make sure the bug hasn't been reported and/or already fixed in the development version.
+Before opening a new issue, be sure to [search issues and pull
+requests](https://github.com/{{github_spec}}/issues) to make sure the bug
+hasn't been reported and/or already fixed in the development version.
 By default, the search will be pre-populated with `is:issue is:open`.
-You can [edit the qualifiers](https://help.github.com/articles/searching-issues-and-pull-requests/)  (e.g. `is:pr`, `is:closed`) as needed.
-For example, you'd simply remove `is:open` to search _all_ issues in the repo, open or closed.
+You can [edit the
+qualifiers](https://help.github.com/articles/searching-issues-and-pull-requests/)
+(e.g. `is:pr`, `is:closed`) as needed.
+For example, you'd simply remove `is:open` to search _all_ issues in the repo,
+open or closed.
 
 ## What happens next?
 
-To be as efficient as possible, development of tidyverse packages tends to be very bursty, so you shouldn't worry if you don't get an immediate response.
-Typically we don't look at a repo until a sufficient quantity of issues accumulates, then there’s a burst of intense activity as we focus our efforts.
-That makes development more efficient because it avoids expensive context switching between problems, at the cost of taking longer to get back to you.
-This process makes a good reprex particularly important because it might be multiple months between your initial report and when we start working on it.
+To be as efficient as possible, development of tidyverse packages tends to be
+very bursty, so you shouldn't worry if you don't get an immediate response.
+Typically we don't look at a repo until a sufficient quantity of issues
+accumulates, then there’s a burst of intense activity as we focus our efforts.
+That makes development more efficient because it avoids expensive context
+switching between problems, at the cost of taking longer to get back to you.
+This process makes a good reprex particularly important because it might be
+multiple months between your initial report and when we start working on it.
 If we can’t reproduce the bug, we can’t fix it!

--- a/inst/templates/bioc-support.md
+++ b/inst/templates/bioc-support.md
@@ -7,13 +7,14 @@ as smooth as possible for both parties.
 ## Make a reprex
 
 Start by making a minimally **repr**oducible **ex**ample, also known as a
-'reprex'. You may use the `reprex` package to create one, though it is not
-necessary but it does help. It will make all of your R-question-asking endeavors
-easier. It takes about 5 to 10 minutes to learn how to use it.
+'reprex'. You may use the [`reprex`](https://reprex.tidyverse.org/) R package to
+create one, though it is not necessary but it does help. It will make all of
+your R-question-asking endeavors easier. Learning
+[how to use it](https://reprex.tidyverse.org/articles/learn-reprex.html) takes
+about 5 to 10 minutes.
 
 For more tips on how to make a minimally **repr**oducible **ex**ample, see this
-link on Stackoverflow:
-<https://stackoverflow.com/questions/5963269/how-to-make-a-great-r-reproducible-example>
+[StackOverflow link](https://stackoverflow.com/questions/5963269/how-to-make-a-great-r-reproducible-example).
 
 ## Where to post it?
 
@@ -44,8 +45,9 @@ to ensure that one does not already exist or has been implemented in the
 development version.
 
 **Note**. You can remove the `is:open` search term in the issues page to search
-through open and closed issues. Learn more about modifying the search at
-<https://help.github.com/articles/searching-issues-and-pull-requests/>
+through open and closed issues. See
+[this link to learn more](https://help.github.com/articles/searching-issues-and-pull-requests/)
+about modifying the search.
 
 ## What happens next?
 

--- a/inst/templates/bioc-support.md
+++ b/inst/templates/bioc-support.md
@@ -1,44 +1,63 @@
 # Getting help with `{{{Package}}}`
 
-Thanks for using `{{{Package}}}`!
-Before filing an issue, there are a few places to explore and pieces to put together to make the process as smooth as possible.
+Thank you for using `{{{Package}}}`!
+Before filing an issue, there are few things you should know to make the process
+as smooth as possible for both parties.
 
 ## Make a reprex
 
-Start by making a minimal **repr**oducible **ex**ample using the [reprex](https://reprex.tidyverse.org/) package.
-If you haven't heard of or used reprex before, you're in for a treat!
-Seriously, reprex will make all of your R-question-asking endeavors easier (which is a pretty insane ROI for the five to ten minutes it'll take you to learn what it's all about).
-For additional reprex pointers, check out the [Get help!](https://www.tidyverse.org/help/) section of the tidyverse site.
+Start by making a minimally **repr**oducible **ex**ample, also known as a
+'reprex'. You may use the `reprex` package to create one, though it is not
+necessary but it does help. It will make all of your R-question-asking endeavors
+easier. It takes about 5 to 10 minutes to learn how to use it.
 
-## Where to ask?
+For more tips on how to make a minimally **repr**oducible **ex**ample, see this
+link on Stackoverflow:
+<https://stackoverflow.com/questions/5963269/how-to-make-a-great-r-reproducible-example>
 
-Armed with your reprex, the next step is to figure out [where to ask](https://www.tidyverse.org/help/#where-to-ask). See also the [Bioconductor help](http://bioconductor.org/help/) website.
+## Where to post it?
 
-*   If it's a question: start with [community.rstudio.com](https://community.rstudio.com/), and/or StackOverflow. If this a Bioconductor-related question, please ask it at the [Bioconductor Support Website](https://support.bioconductor.org/) using the [appropriate package tag](https://support.bioconductor.org/t/{{{Package}}}) (the website will send an automatic email to the package authors). There are more people there to answer questions.
+The [Bioconductor help](http://bioconductor.org/help/) web page gives an
+overview of places that may help answer your question.
 
-*   If it's a bug: you're in the right place, [file an issue](https://github.com/{{github_spec}}/issues/new).
+* Bioconductor software related questions, such as bug reports and feature
+  requests, should be addressed in the appropriate `Bioconductor/{{{Package}}}`
+  GitHub repository. Follow our bug report and feature request templates on
+  GitHub. If the package does not have a GitHub repository, see the next bullet
+  point.
 
-*   If you're not sure: let the community help you figure it out!
-    If your problem _is_ a bug or a feature request, you can easily return here and report it.
+* Bioconductor software usage questions should be addressed in the
+  [Bioconductor Support Website](https://support.bioconductor.org/). Make sure
+  to use the
+  [appropriate package tag](https://support.bioconductor.org/t/{{{Package}}}),
+  otherwise the package authors will not get a notification.
+  
+* General R questions can be posed at StackOverflow or at the
+  [RStudio Community](https://community.rstudio.com/) website especially if they
+  pertain to the `tidyverse` or the RStudio GUI or related products.
 
-Before opening a new issue, be sure to [search issues and pull
-requests](https://github.com/{{github_spec}}/issues) to make sure the bug
-hasn't been reported and/or already fixed in the development version.
-By default, the search will be pre-populated with `is:issue is:open`.
-You can [edit the
-qualifiers](https://help.github.com/articles/searching-issues-and-pull-requests/)
-(e.g. `is:pr`, `is:closed`) as needed.
-For example, you'd simply remove `is:open` to search _all_ issues in the repo,
-open or closed.
+## Issues or Feature Requests
+
+Before opening a new issue or feature request, be sure to
+[search issues and pull requests](https://github.com/{{github_spec}}/issues)
+to ensure that one does not already exist or has been implemented in the
+development version.
+
+**Note**. You can remove the `is:open` search term in the issues page to search
+through open and closed issues. Learn more about modifying the search at
+<https://help.github.com/articles/searching-issues-and-pull-requests/>
 
 ## What happens next?
 
-To be as efficient as possible, development of tidyverse packages tends to be
-very bursty, so you shouldn't worry if you don't get an immediate response.
-Typically we don't look at a repo until a sufficient quantity of issues
-accumulates, then there’s a burst of intense activity as we focus our efforts.
-That makes development more efficient because it avoids expensive context
-switching between problems, at the cost of taking longer to get back to you.
-This process makes a good reprex particularly important because it might be
-multiple months between your initial report and when we start working on it.
-If we can’t reproduce the bug, we can’t fix it!
+Our Bioconductor maintainers are limited in resources but they do strive to be
+as responsive as possible.
+
+Please do not forget to tag the appropriate maintainer in the issue with their
+GitHub username (e.g., @username).
+
+In order to make it easy as possible for Bioconductor core developers to
+remediate the issue. Provide an accurate, brief, and reproducible report
+as outlined in the issue templates.
+
+Thank you for trusting Bioconductor.
+


### PR DESCRIPTION
Hi Leo, @lcolladotor 

We were looking at having separate templates for bug reports and feature requests. 
Some of the language here is taken from Martin's templates at [@bioconductor/Rsamtools](https://github.com/Bioconductor/Rsamtools/tree/master/.github/ISSUE_TEMPLATE). 
Let us know what you think. 
For brevity, I've removed the link examples you had in the templates.
Perhaps those can be added in the `Support` template?
They could be titled something like 'providing relevant GitHub links'. 

Best,
Marcel