### PR TITLE
Update actions/cache to v3

### DIFF
--- a/inst/templates/check-bioc.yml
+++ b/inst/templates/check-bioc.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Restore R package cache
         if: "!contains(github.event.head_commit.message, '/nocache') && runner.os != 'Linux'"
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ env.cache-version }}-${{ runner.os }}-biocversion-{{dockerversion}}-r-{{rvernum}}-${{ hashFiles('.github/depends.Rds') }}
@@ -110,7 +110,7 @@ jobs:
 
       - name: Cache R packages on Linux
         if: "!contains(github.event.head_commit.message, '/nocache') && runner.os == 'Linux' "
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /home/runner/work/_temp/Library
           key: ${{ env.cache-version }}-${{ runner.os }}-biocversion-{{dockerversion}}-r-{{rvernum}}-${{ hashFiles('.github/depends.Rds') }}


### PR DESCRIPTION
I'm getting this warning from my job when using actions/cache@v2:

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/cache

See:
- https://github.com/marketplace/actions/cache